### PR TITLE
Allow any address match order 

### DIFF
--- a/src/DoefinV1OrderBook.sol
+++ b/src/DoefinV1OrderBook.sol
@@ -52,9 +52,9 @@ contract DoefinV1OrderBook is IDoefinV1OrderBook, ERC1155 {
         uint256 amount,
         uint256 expiry,
         bool isLong,
-        address[] memory allowed
+        address[] calldata allowed
     )
-        public
+        external
         returns (uint256)
     {
         if (strike == 0) {
@@ -97,13 +97,17 @@ contract DoefinV1OrderBook is IDoefinV1OrderBook, ERC1155 {
     }
 
     //@@inheritdoc
-    function matchOrder(uint256 orderId) public {
+    function matchOrder(uint256 orderId) external {
         BinaryOption storage order = orders[orderId];
         uint256 amount = order.amount;
         uint256 premium = (amount * 2) / 100; //1% of bet amount
 
         if (block.timestamp > order.exerciseWindowStart) {
             revert Errors.OrderBook_MatchOrderExpired();
+        }
+
+        if (order.counterparty != address(0)) {
+            revert Errors.OrderBook_OrderAlreadyMatched();
         }
 
         address[] memory allowed = order.allowed;
@@ -138,7 +142,7 @@ contract DoefinV1OrderBook is IDoefinV1OrderBook, ERC1155 {
     }
 
     //@@inheritdoc
-    function exerciseOrder(uint256 orderId) public returns (uint256) {
+    function exerciseOrder(uint256 orderId) external returns (uint256) {
         BinaryOption storage order = orders[orderId];
         address winner;
 
@@ -174,7 +178,7 @@ contract DoefinV1OrderBook is IDoefinV1OrderBook, ERC1155 {
         uint256 blockNumber,
         uint256 difficulty
     )
-        public
+        external
         onlyOptionsManager
         returns (bool)
     {
@@ -188,7 +192,7 @@ contract DoefinV1OrderBook is IDoefinV1OrderBook, ERC1155 {
     }
 
     //@@inheritdoc
-    function getOrder(uint256 orderId) public view returns (BinaryOption memory) {
+    function getOrder(uint256 orderId) external view returns (BinaryOption memory) {
         return orders[orderId];
     }
 

--- a/src/interfaces/IDoefinV1OrderBook.sol
+++ b/src/interfaces/IDoefinV1OrderBook.sol
@@ -124,7 +124,7 @@ interface IDoefinV1OrderBook {
         uint256 amount,
         uint256 expiry,
         bool isLong,
-        address[] memory allowed
+        address[] calldata allowed
     )
         external
         returns (uint256);

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -52,4 +52,7 @@ library Errors {
 
     /// @notice Thrown when the match order amount is incorrect
     error OrderBook_UnableToMatchOrder();
+
+    /// @notice Thrown when the order is already matched
+    error OrderBook_OrderAlreadyMatched();
 }

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -42,6 +42,8 @@ abstract contract Base_Test is Test, Assertions, Constants {
         users = Users({
             admin: createUser("Admin"),
             alice: createUser("Alice"),
+            james: createUser("James"),
+            rick: createUser("Rick"),
             broker: createUser("Broker"),
             feeAddress: createUser("FeeAddress")
         });

--- a/test/utils/Types.sol
+++ b/test/utils/Types.sol
@@ -6,6 +6,10 @@ struct Users {
     address payable admin;
     // User Alice.
     address payable alice;
+    // User Alice.
+    address payable james;
+    // User Alice.
+    address payable rick;
     // User broker.
     address payable broker;
     // User Fee Address


### PR DESCRIPTION
This PR adds the logic to allow any address match order when counterparty address is not set. You may refer to this conversation [here](https://github.com/Doefin/v1-core/pull/2#discussion_r1646768447). @Cody-G-G Please let me know if there are further changes to this specific PR. 