### PR TITLE
Fix reported bugs from end-to-end testing

### DIFF
--- a/src/DoefinV1OrderBook.sol
+++ b/src/DoefinV1OrderBook.sol
@@ -86,6 +86,7 @@ contract DoefinV1OrderBook is IDoefinV1OrderBook, ERC1155, Ownable, ReentrancyGu
             createOrderInput.premium,
             createOrderInput.notional,
             createOrderInput.strike,
+            createOrderInput.deadline,
             createOrderInput.position,
             createOrderInput.expiry,
             createOrderInput.expiryType
@@ -188,6 +189,7 @@ contract DoefinV1OrderBook is IDoefinV1OrderBook, ERC1155, Ownable, ReentrancyGu
             order.premium,
             order.notional,
             order.strike,
+            0,
             order.position,
             order.expiry,
             order.expiryType
@@ -318,8 +320,9 @@ contract DoefinV1OrderBook is IDoefinV1OrderBook, ERC1155, Ownable, ReentrancyGu
 
         // Update position
         if (updateOrder.position != order.positions.makerPosition) {
+            order.positions.takerPosition = order.positions.makerPosition;
             order.positions.makerPosition = updateOrder.position;
-            emit OrderPositionUpdated(orderId, updateOrder.position);
+            emit OrderPositionUpdated(orderId, updateOrder.position, order.positions.takerPosition);
         }
 
         // Update expiry

--- a/src/interfaces/IDoefinV1OrderBook.sol
+++ b/src/interfaces/IDoefinV1OrderBook.sol
@@ -151,6 +151,7 @@ interface IDoefinV1OrderBook {
         uint256 premium,
         uint256 notional,
         uint256 strike,
+        uint256 deadline,
         Position position,
         uint256 expiry,
         ExpiryType expiryType
@@ -202,8 +203,9 @@ interface IDoefinV1OrderBook {
 
     /// @notice Emitted when a maker's order position is updated
     /// @param id The order id
-    /// @param position The maker's new position
-    event OrderPositionUpdated(uint256 indexed id, Position position);
+    /// @param makerPosition The maker's new position
+    /// @param takerPosition The taker's new position
+    event OrderPositionUpdated(uint256 indexed id, Position makerPosition, Position takerPosition);
 
     /// @notice Emitted when a order's deadline is updated
     /// @param id The order id

--- a/test/DoefinV1OrderBook.t.sol
+++ b/test/DoefinV1OrderBook.t.sol
@@ -165,6 +165,7 @@ contract DoefinV1OrderBook_Test is Base_Test {
             createOrderInput.premium,
             createOrderInput.notional,
             createOrderInput.strike,
+            createOrderInput.deadline,
             createOrderInput.position,
             createOrderInput.expiry,
             createOrderInput.expiryType
@@ -340,6 +341,7 @@ contract DoefinV1OrderBook_Test is Base_Test {
             createOrderInput.premium,
             createOrderInput.notional,
             createOrderInput.strike,
+            createOrderInput.deadline,
             createOrderInput.position,
             createOrderInput.expiry,
             createOrderInput.expiryType
@@ -439,7 +441,7 @@ contract DoefinV1OrderBook_Test is Base_Test {
         vm.expectEmit();
         emit IDoefinV1OrderBook.OrderDeadlineUpdated(orderId, updateParams.deadline);
         vm.expectEmit();
-        emit IDoefinV1OrderBook.OrderPositionUpdated(orderId, updateParams.position);
+        emit IDoefinV1OrderBook.OrderPositionUpdated(orderId, updateParams.position, IDoefinV1OrderBook.Position.Below);
         vm.expectEmit();
         emit IDoefinV1OrderBook.OrderExpiryUpdated(orderId, updateParams.expiry, updateParams.expiryType);
         vm.expectEmit();
@@ -455,6 +457,7 @@ contract DoefinV1OrderBook_Test is Base_Test {
         assertEq(updatedOrder.premiums.notional, updateParams.notional);
         assertEq(updatedOrder.premiums.makerPremium, updateParams.premium);
         assertEq(uint8(updatedOrder.positions.makerPosition), uint8(updateParams.position));
+        assertEq(uint8(updatedOrder.positions.takerPosition), uint8(IDoefinV1OrderBook.Position.Below));
         assertEq(updatedOrder.metadata.expiry, updateParams.expiry);
         assertEq(uint8(updatedOrder.metadata.expiryType), uint8(updateParams.expiryType));
         assertEq(updatedOrder.metadata.allowed.length, updateParams.allowed.length);
@@ -833,7 +836,7 @@ contract DoefinV1OrderBook_Test is Base_Test {
         uint256 expiry = block.timestamp + 2 days;
 
         vm.assume(strike != 0);
-        vm.assume(multiplier > 1 && multiplier <= 1000);
+        bound(multiplier, 1, 1000);
 
         uint256 premium = minCollateralAmount * multiplier;
         vm.assume(counterparty == users.rick || counterparty == users.james);

--- a/utils/script/fetchBlocks.js
+++ b/utils/script/fetchBlocks.js
@@ -20,7 +20,7 @@ function formatBlockHeader(block) {
     prevBlockHash: `0x${block.prev_block}`,
     merkleRootHash: `0x${block.mrkl_root}`,
     timestamp: Math.floor(new Date(block.time).getTime() / 1000),
-    nBits: block.bits,
+    nBits: `0x${block.bits.toString(16)}`,
     nonce: block.nonce,
     blockHash: `0x${block.hash}`,
     blockNumber: block.height


### PR DESCRIPTION
This PR fixes bugs from the end-to-end tests conducted by the team:
1. Update order bug: When a maker updates their position, the position of the taker does not change.
  status: fixed
2. Added an additional properties to the `OrderCreated` and `OrderUpdated` event. 